### PR TITLE
Changes to be committed:

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,8 +3,8 @@
 * @desc This page lists all the instances of wwassignments within a particular course.
 */
 
-require_once("../../config.php");
-require_once("locallib.php");
+require_once(dirname(__FILE__) . "/../../config.php");
+require_once(dirname(__FILE__) . "/locallib.php");
 
 // global database object
 global $DB,$OUTPUT,$PAGE;

--- a/lib.php
+++ b/lib.php
@@ -1,6 +1,6 @@
 <?php
 global $CFG, $DB;
-require_once("locallib.php");
+require_once(dirname(__FILE__) . "/locallib.php");
 
 // debug switch defined in locallib.php  define('WWASSIGNMENT_DEBUG',0);
 
@@ -91,7 +91,6 @@ function wwassignment_add_instance($wwassignment) {
 */
 function wwassignment_update_instance($wwassignment) {
     global $COURSE,$DB;
-    require_once("locallib.php");
     traceLog("---------Begin wwassignment_update_instance---------");
     
 
@@ -185,8 +184,6 @@ function wwassignment_get_user_grades($wwassignment,$userid=0) {
 	traceLog("------Begin wwassignment_get_user_grades -- fetch grades from WW -----");
 	debugLog("inputs -- wwassignment" . print_r($wwassignment,true));
 	debugLog("userid = $userid");
-	
-	require_once("locallib.php");
 	
 	//checking mappings
 	$courseid = $wwassignment->course;

--- a/mod_form.php
+++ b/mod_form.php
@@ -1,6 +1,6 @@
 <?php
-require_once('moodleform_mod.php');
-require_once('locallib.php');
+require_once("$CFG->dirroot/course/moodleform_mod.php");
+require_once(dirname(__FILE__) . "locallib.php");
 
 class mod_wwassignment_mod_form extends moodleform_mod
 {

--- a/view.php
+++ b/view.php
@@ -7,8 +7,8 @@
 // global database object
 global $DB,$OUTPUT,$PAGE;
 
-require_once("../../config.php");
-require_once("locallib.php");
+require_once(dirname(__FILE__) . "/../../config.php");
+require_once(dirname(__FILE__) . "/locallib.php");
 
 
 


### PR DESCRIPTION
      modified:   index.php
      modified:   lib.php
      modified:   mod_form.php
      modified:   view.php

From: https://secure.php.net/manual/en/function.include.php

"Files are included based on the file path given or, if none is given,
the include_path specified. If the file isn't found in the include_path,
include will finally check in the calling script's own directory and the
current working directory before failing. "

In some cases, the require_once('locallib.php') call was finding other
instances of locallib.php in the moodle code and ending, rather than
loading this plugins code.

Notably, I experienced this with attempts to recover grade histories
for students getting re-enrolled in courses with an instance of this
module in their grade history